### PR TITLE
gettext is also a dependency on ubuntu

### DIFF
--- a/docs/ubuntu-deps.md
+++ b/docs/ubuntu-deps.md
@@ -18,7 +18,7 @@ Runtime Dependencies
     $ sudo apt-get install python-cherrypy3 python-cheetah python-pam \
                             python-m2crypto python-jsonschema \
                             python-psutil python-ldap python-lxml nginx \
-                            openssl fonts-font-awesome websockify
+                            openssl fonts-font-awesome websockify gettext
 
 Packages required for UI development
 ------------------------------------


### PR DESCRIPTION
Ubuntu-1604-xenial-64-minimal ~ # dpkg -i wok.noarch.deb
Selecting previously unselected package wok.
(Reading database ... 74631 files and directories currently installed.)
Preparing to unpack wok.noarch.deb ...
Unpacking wok (2.5.0) ...
dpkg: dependency problems prevent configuration of wok:
 wok depends on gettext; however:
  Package gettext is not installed.

dpkg: error processing package wok (--install):
 dependency problems - leaving unconfigured
Processing triggers for man-db (2.7.5-1) ...
Errors were encountered while processing:
 wok