### PR TITLE
Issue #238: Fixes a bug when XMLs do not contain valid UTF-8

### DIFF
--- a/src/wok/xmlutils/utils.py
+++ b/src/wok/xmlutils/utils.py
@@ -67,7 +67,7 @@ def xml_item_remove(xml, xpath):
 
 
 def dictize(xmlstr):
-    root = objectify.fromstring(xmlstr)
+    root = objectify.fromstring(xmlstr.decode('utf-8','ignore').encode("utf-8"))
     return {root.tag: _dictize(root)}
 
 


### PR DESCRIPTION
In Issue #238 I was having an issue with my server reporting incorrect/corrupted information in the XML returned from libvirt. Locally, I was able to resolve this problem by decoding the malformed UTF-8, ignoring errors, then re-encoding. I have tested this on my local installation, and it doesn't seem to break anything.