### PR TITLE
Issue #234: timeout_monitor is removed in cherrypy > 12.0.0

### DIFF
--- a/src/wok/server.py
+++ b/src/wok/server.py
@@ -91,7 +91,7 @@ class Server(object):
         # thus it is safe to unsubscribe.
         try:
             cherrypy.engine.timeout_monitor.unsubscribe()
-        except(AssertionError):
+        except(AttributeError):
             pass
 
         cherrypy.tools.nocache = cherrypy.Tool('on_end_resource', set_no_cache)

--- a/src/wok/server.py
+++ b/src/wok/server.py
@@ -89,7 +89,11 @@ class Server(object):
         # nginx timeout (= 10 minutes). This monitor isn't involved
         # in anything other than monitor the timeout of the connection,
         # thus it is safe to unsubscribe.
-        cherrypy.engine.timeout_monitor.unsubscribe()
+        try:
+            cherrypy.engine.timeout_monitor.unsubscribe()
+        except(AssertionError):
+            pass
+
         cherrypy.tools.nocache = cherrypy.Tool('on_end_resource', set_no_cache)
         cherrypy.tools.wokauth = cherrypy.Tool('before_handler', auth.wokauth)
 


### PR DESCRIPTION
The upstream cherrypy repository has removed `timeout_monitor` which causes an immediate crash in wokd. This change checks for an `AttributeError`, which indicates that there is no `timeout_monitor` to unsubscribe from. This should be sufficient as the default in CherryPy is now to not acknowledge timeouts and to let the upstream servers handle it.