### PR TITLE
Fix cert generation on Python 3

### DIFF
--- a/src/wok/proxy.py
+++ b/src/wok/proxy.py
@@ -68,9 +68,9 @@ def check_proxy_config():
 
     if not os.path.exists(cert) or not os.path.exists(key):
         ssl_gen = sslcert.SSLCert()
-        with open(cert, 'w') as f:
+        with open(cert, 'wb') as f:
             f.write(ssl_gen.cert_pem())
-        with open(key, 'w') as f:
+        with open(key, 'wb') as f:
             f.write(ssl_gen.key_pem())
 
     # Reload nginx configuration.


### PR DESCRIPTION
By default on Python 3, file I/O is string-based. Using 'wb' opens the output file for binary writes. Without this, wokd crashes with `TypeError: write() argument must be str, not bytes` if the HTTPS cert is not yet generated.