### PR TITLE
Pyrthon 3 can use unicode characters internally.

### DIFF
--- a/src/wok/stringutils.py
+++ b/src/wok/stringutils.py
@@ -46,7 +46,7 @@ def encode_value(val):
         If its unicode, use encode otherwise str.
     """
     if isinstance(val, str):
-        return val.encode('utf-8')
+        return val
     return str(val)
 
 


### PR DESCRIPTION
Ubuntu 19.04, wok and kimchi installed from generated deb.
The network interace (bridge) choosing wasn't work. After debugging, I saw it's string conversion error.