### PR TITLE
fix fails on git clone --recursive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 	url = https://github.com/kimchi-project/ginger.git
 	ignore = all
 	branch = master
-[submodule "src/wok/plugins/gingerbase"]
-	path = src/wok/plugins/gingerbase
-	url = https://github.com/kimchi-project/gingerbase.git
-	ignore = all
-	branch = master
+#[submodule "src/wok/plugins/gingerbase"]
+#	path = src/wok/plugins/gingerbase
+#	url = https://github.com/kimchi-project/gingerbase.git
+#	ignore = all
+#	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 	url = https://github.com/kimchi-project/ginger.git
 	ignore = all
 	branch = master
-#[submodule "src/wok/plugins/gingerbase"]
-#	path = src/wok/plugins/gingerbase
-#	url = https://github.com/kimchi-project/gingerbase.git
-#	ignore = all
-#	branch = master
+[submodule "src/wok/plugins/gingerbase"]
+	path = src/wok/plugins/gingerbase
+	url = https://github.com/kimchi-project/gingerbase.git
+	ignore = all
+	branch = master


### PR DESCRIPTION
Hello,

When cloning (via ansible or directly via git cli) recursively, it fails because gingerbase 4da64e43f17c181927c1b56fb3f86574f4874af7 is unavailable.

So, i removed the submodule and added it again to have the last (existing) version.

thanks!

> gnieark@gnieark-Lenovo-B50-10:~$ git clone --recursive https://github.com/kimchi-project/wok.git
> Clonage dans 'wok'...
> remote: Enumerating objects: 20, done.
> remote: Counting objects: 100% (20/20), done.
> remote: Compressing objects: 100% (17/17), done.
> remote: Total 23568 (delta 7), reused 7 (delta 3), pack-reused 23548
> (...)
> Chemin de sous-module 'src/wok/plugins/ginger' : '8121ef5b8489c253a8ceec04a0751b26af0d3fbb' extrait
> error: Le serveur n'autorise pas de requête pour l'objet 4da64e43f17c181927c1b56fb3f86574f4874af7 non annoncé
> Chemin de sous-module 'src/wok/plugins/gingerbase' récupéré, mais il ne contenait pas 4da64e43f17c181927c1b56fb3f86574f4874af7. La récupération directe de ce commit a échoué.
