### PR TITLE
Fix CI by using pip for python packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ po/gen-pot
 *.orig
 *.rej
 *.pem
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-language: generic
+language: python
+python:
+  - "3.6"
+
 sudo: enabled
 
 git:
   submodules: false
 
 before_install:
+  - pip install -r requirements-travis.txt
   - sudo apt -qq update
-  - sudo apt install -y $(grep "^[^#;]" ubuntu-dev-deps.list)
-  - sudo apt install -y $(grep "^[^#;]" ubuntu-runtime-deps.list)
+  - sudo apt install -y automake git python3-pip gettext pkgconf xsltproc python3-dev systemd logrotate openssl nginx gettext
   - ./autogen.sh --system
 
 install: make

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,0 +1,15 @@
+jsonschema
+psutil
+python-ldap
+lxml
+websockify
+m2crypto
+cheetah3
+CherryPy
+python-pam
+pyOpenSSL
+requests
+mock
+pyyaml
+pep8
+pyflakes


### PR DESCRIPTION
To avoid problems with packages from distro, use pip to manage python
dependencies