### PR TITLE
Prevent errors due to concurrent modification of tasks_queue

### DIFF
--- a/src/wok/asynctask.py
+++ b/src/wok/asynctask.py
@@ -40,7 +40,7 @@ def clean_old_tasks():
     Remove from tasks_queue any task that started before 12 hours ago and has
     current status equal do finished or failed.
     """
-    for id, task in tasks_queue.items():
+    for id, task in tasks_queue.copy().items():
         if task.timestamp < (time.time() - 43200):
             if (task.status == 'finished') or (task.status == 'failed'):
                 task.remove()


### PR DESCRIPTION
# Handle concurrent modification of tasks_queue

## Description

Currently if tasks_queue is modified while the for loop is executing, an error is produced.
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wok/asynctask.py", line 109, in _run_helper
    self.fn(cb, opaque)
  File "/usr/lib/python3/dist-packages/wok/plugins/kimchi/model/vms.py", line 465, in _clone_task
    xml = self._clone_update_disks(xml, rollback)
  File "/usr/lib/python3/dist-packages/wok/plugins/kimchi/model/vms.py", line 608, in _clone_update_disks
    orig_pool_name, orig_vol_name, new_name=new_vol_name
  File "/usr/lib/python3/dist-packages/wok/plugins/kimchi/model/storagevolumes.py", line 483, in clone
    self._clone_task, params).id
  File "/usr/lib/python3/dist-packages/wok/asynctask.py", line 79, in __init__
    clean_old_tasks()
  File "/usr/lib/python3/dist-packages/wok/asynctask.py", line 43, in clean_old_tasks
    for id, task in tasks_queue.items().copy():
RuntimeError: dictionary changed size during iteration
```
Fixes # https://github.com/kimchi-project/kimchi/issues/1315

## How Has This Been Tested?

Please, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Clone a VM sucessfully

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have signed-off my commit (git commit -s) to certify I have the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see http://developercertificate.org/ for more information).
- [ ] My code follows the style guidelines of this project and I have run `make check-local` to confirm it.
- [ ] I have run `make` to build the project and update any documentation that was added as part of this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (Run `make check` to confirm it)
